### PR TITLE
Modify field attributes to pickle instance efficiently

### DIFF
--- a/collatable/fields/adjacency_field.py
+++ b/collatable/fields/adjacency_field.py
@@ -48,6 +48,12 @@ class AdjacencyField(Field[Tensor]):
                 assert indexer is not None
                 self._indexed_labels = [indexer(label) for label in cast(Sequence[str], self._labels)]
 
+    def __str__(self) -> str:
+        return f"[{', '.join(str(index) for index in self._indices)}]"
+
+    def __repr__(self) -> str:
+        return f"AdjacencyField(indices={self._indices}, padding_value={self._padding_value})"
+
     @staticmethod
     def _make_indexer(vocab: Mapping[str, int]) -> Callable[[str], int]:
         def indexer(label: str) -> int:

--- a/collatable/fields/field.py
+++ b/collatable/fields/field.py
@@ -18,7 +18,7 @@ class Field(abc.ABC, Generic[T_DataArray]):
         if not isinstance(padding_value, dict):
             padding_value = {"": padding_value}
 
-        self.padding_value = padding_value
+        self._padding_value = padding_value
 
     def __eq__(self: Self, other: object) -> bool:
         if isinstance(self, other.__class__):
@@ -30,6 +30,10 @@ class Field(abc.ABC, Generic[T_DataArray]):
                 return self.__dict__ == other.__dict__
             return True
         return NotImplemented
+
+    @property
+    def padding_value(self) -> Dict[str, ArrayLike]:
+        return self._padding_value
 
     def collate(self: Self, arrays: Union[Sequence[T_DataArray], Sequence[Self]]) -> T_DataArray:
         if isinstance(arrays[0], Field):

--- a/collatable/fields/index_field.py
+++ b/collatable/fields/index_field.py
@@ -6,15 +6,18 @@ from collatable.typing import Tensor
 
 
 class IndexField(Field[Tensor]):
-    __slots__ = ["index", "sequence"]
+    __slots__ = ["_index"]
 
     def __init__(self, index: int, sequence: SequenceField) -> None:
         if index < 0 or index >= len(sequence):
             raise ValueError(f"Index {index} is out of range for sequence of length {len(sequence)}")
 
         super().__init__(padding_value=-1)
-        self.index = index
-        self.sequence = sequence
+        self._index = index
+
+    @property
+    def index(self) -> int:
+        return self._index
 
     def as_array(self) -> Tensor:
         return numpy.array(self.index)

--- a/collatable/fields/index_field.py
+++ b/collatable/fields/index_field.py
@@ -15,6 +15,12 @@ class IndexField(Field[Tensor]):
         super().__init__(padding_value=-1)
         self._index = index
 
+    def __str__(self) -> str:
+        return str(self._index)
+
+    def __repr__(self) -> str:
+        return f"IndexField(index={self._index})"
+
     @property
     def index(self) -> int:
         return self._index

--- a/collatable/fields/label_field.py
+++ b/collatable/fields/label_field.py
@@ -35,6 +35,12 @@ class LabelField(Field[Tensor]):
             assert indexer is not None
             self._label_index = indexer(label)
 
+    def __str__(self) -> str:
+        return str(self._label)
+
+    def __repr__(self) -> str:
+        return f"LabelField(label={self._label})"
+
     @property
     def label(self) -> Union[int, str]:
         return self._label

--- a/collatable/fields/label_field.py
+++ b/collatable/fields/label_field.py
@@ -9,7 +9,7 @@ Self = TypeVar("Self", bound="LabelField")
 
 
 class LabelField(Field[Tensor]):
-    __slots__ = ["label", "label_index", "indexer"]
+    __slots__ = ["_label", "_label_index"]
 
     def __init__(
         self,
@@ -27,19 +27,20 @@ class LabelField(Field[Tensor]):
             indexer = self._make_indexer(vocab)
 
         super().__init__()
-        self.label = label
-        self.indexer = indexer
+        self._label = label
+        self._label_index: int
         if isinstance(label, int):
-            self.label_index = label
+            self._label_index = label
         else:
             assert indexer is not None
-            self.label_index = indexer(label)
+            self._label_index = indexer(label)
 
-    def copy(self: Self) -> Self:
-        return self.__class__(label=self.label, indexer=self.indexer)
+    @property
+    def label(self) -> Union[int, str]:
+        return self._label
 
     def as_array(self) -> Tensor:
-        return numpy.array(self.label_index, dtype=numpy.int32)
+        return numpy.array(self._label_index, dtype=numpy.int32)
 
     @staticmethod
     def _make_indexer(vocab: Mapping[str, int]) -> Callable[[str], int]:

--- a/collatable/fields/list_field.py
+++ b/collatable/fields/list_field.py
@@ -1,16 +1,20 @@
-from typing import Generic, Iterator, Sequence
+from typing import Generic, Iterator, Optional, Sequence
 
-from collatable.fields.field import Field
+from collatable.fields.field import Field, PaddingValue
 from collatable.fields.sequence_field import SequenceField
 from collatable.typing import T_DataArray
 
 
 class ListField(Generic[T_DataArray], SequenceField[T_DataArray]):
-    __slots__ = ["fields"]
+    __slots__ = ["_fields", "_padding_value"]
 
-    def __init__(self, fields: Sequence[Field[T_DataArray]]) -> None:
-        super().__init__(padding_value=fields[0].padding_value)
-        self.fields: Sequence[Field[T_DataArray]] = fields
+    def __init__(
+        self,
+        fields: Sequence[Field[T_DataArray]],
+        padding_value: Optional[PaddingValue] = None,
+    ) -> None:
+        super().__init__(padding_value=padding_value if padding_value is not None else fields[0].padding_value)
+        self._fields: Sequence[Field[T_DataArray]] = fields
 
     def __len__(self) -> int:
         return len(self.fields)
@@ -20,6 +24,16 @@ class ListField(Generic[T_DataArray], SequenceField[T_DataArray]):
 
     def __getitem__(self, index: int) -> Field[T_DataArray]:
         return self.fields[index]
+
+    def __str__(self) -> str:
+        return f"[{', '.join(str(field) for field in self._fields)}]"
+
+    def __repr__(self) -> str:
+        return f"ListField(fields={self._fields}, padding_value={self._padding_value})"
+
+    @property
+    def fields(self) -> Sequence[Field[T_DataArray]]:
+        return self._fields
 
     def as_array(self) -> T_DataArray:
         return self.fields[0].collate(self.fields)

--- a/collatable/fields/metadata_field.py
+++ b/collatable/fields/metadata_field.py
@@ -4,14 +4,18 @@ from collatable.fields.field import Field
 
 
 class MetadataField(Field):
-    __slots__ = ["metadata"]
+    __slots__ = ["_metadata"]
 
     def __init__(self, metadata: Any) -> None:
         super().__init__()
-        self.metadata = metadata
+        self._metadata = metadata
+
+    @property
+    def metadata(self) -> Any:
+        return self._metadata
 
     def as_array(self) -> Any:
-        return self.metadata
+        return self._metadata
 
     def collate(self, arrays: Sequence[Any]) -> List[Any]:
         if isinstance(arrays[0], Field):

--- a/collatable/fields/metadata_field.py
+++ b/collatable/fields/metadata_field.py
@@ -10,6 +10,12 @@ class MetadataField(Field):
         super().__init__()
         self._metadata = metadata
 
+    def __str__(self) -> str:
+        return str(self._metadata)
+
+    def __repr__(self) -> str:
+        return f"MetadataField(metadata={self._metadata})"
+
     @property
     def metadata(self) -> Any:
         return self._metadata

--- a/collatable/fields/scalar_field.py
+++ b/collatable/fields/scalar_field.py
@@ -20,5 +20,11 @@ class ScalarField(Field[Tensor]):
         super().__init__(padding_value=padding_value)
         self._value: T_Scalar = value
 
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def __repr__(self) -> str:
+        return f"ScalarField(value={self._value}, padding_value={self._padding_value})"
+
     def as_array(self) -> Tensor:
         return numpy.array(self._value)

--- a/collatable/fields/scalar_field.py
+++ b/collatable/fields/scalar_field.py
@@ -8,7 +8,7 @@ from collatable.util import get_scalar_default_value
 
 
 class ScalarField(Field[Tensor]):
-    __slots__ = ["value", "padding_value"]
+    __slots__ = ["_value", "_padding_value"]
 
     def __init__(
         self,
@@ -18,7 +18,7 @@ class ScalarField(Field[Tensor]):
         if padding_value is None:
             padding_value = get_scalar_default_value(type(value))
         super().__init__(padding_value=padding_value)
-        self.value: T_Scalar = value
+        self._value: T_Scalar = value
 
     def as_array(self) -> Tensor:
-        return numpy.array(self.value)
+        return numpy.array(self._value)

--- a/collatable/fields/sequence_label_field.py
+++ b/collatable/fields/sequence_label_field.py
@@ -1,4 +1,4 @@
-from typing import Callable, Mapping, Optional, Sequence, Union, cast
+from typing import Callable, Iterator, Mapping, Optional, Sequence, Union, cast
 
 import numpy
 
@@ -8,9 +8,11 @@ from collatable.typing import Tensor
 
 
 class SequenceLabelField(SequenceField[Tensor]):
+    __slots__ = ["_labels", "_indexed_labels"]
+
     def __init__(
         self,
-        labels: Union[Sequence[str], Sequence[int]],
+        labels: Union[Sequence[int], Sequence[str]],
         sequence_field: SequenceField,
         *,
         vocab: Optional[Mapping[str, int]] = None,
@@ -26,17 +28,31 @@ class SequenceLabelField(SequenceField[Tensor]):
 
         super().__init__(padding_value=padding_value)
 
-        self.labels: Union[Sequence[str], Sequence[int]] = labels
-        self.indexer = indexer
-        self.sequence_field = sequence_field
+        self._labels = labels
         self._indexed_labels: Sequence[int]
-        if isinstance(self.labels[0], int):
-            self._indexed_labels = cast(Sequence[int], self.labels)
+        if isinstance(self._labels[0], int):
+            self._indexed_labels = cast(Sequence[int], self._labels)
         else:
-            if self.indexer is None:
+            if indexer is None:
                 raise ValueError("Indexer must be specified if labels are strings.")
-            self.labels = cast(Sequence[str], self.labels)
-            self._indexed_labels = [self.indexer(label) for label in self.labels]
+            self._labels = self._labels
+            self._indexed_labels = [indexer(label) for label in cast(Sequence[str], self._labels)]
+
+    def __len__(self) -> int:
+        return len(self._labels)
+
+    def __iter__(self) -> Iterator[Union[int, str]]:
+        return iter(self._labels)
+
+    def __getitem__(self, index: int) -> Union[int, str]:
+        return self._labels[index]
+
+    @property
+    def labels(self) -> Union[Sequence[int], Sequence[str]]:
+        return self._labels
+
+    def as_array(self) -> Tensor:
+        return numpy.array(self._indexed_labels)
 
     @staticmethod
     def _make_indexer(vocab: Mapping[str, int]) -> Callable[[str], int]:
@@ -44,6 +60,3 @@ class SequenceLabelField(SequenceField[Tensor]):
             return vocab[label]
 
         return indexer
-
-    def as_array(self) -> Tensor:
-        return numpy.array(self._indexed_labels)

--- a/collatable/fields/sequence_label_field.py
+++ b/collatable/fields/sequence_label_field.py
@@ -47,6 +47,12 @@ class SequenceLabelField(SequenceField[Tensor]):
     def __getitem__(self, index: int) -> Union[int, str]:
         return self._labels[index]
 
+    def __str__(self) -> str:
+        return f"[{', '.join(str(label) for label in self._labels)}]"
+
+    def __repr__(self) -> str:
+        return f"SequenceLabelField(labels={self._labels}, padding_value={self._padding_value})"
+
     @property
     def labels(self) -> Union[Sequence[int], Sequence[str]]:
         return self._labels

--- a/collatable/fields/span_field.py
+++ b/collatable/fields/span_field.py
@@ -29,6 +29,12 @@ class SpanField(Field[Tensor]):
         self._span_start = span_start
         self._span_end = span_end
 
+    def __str__(self) -> str:
+        return f"({self.span_start}, {self.span_end})"
+
+    def __repr__(self) -> str:
+        return f"SpanField(span_start={self.span_start}, span_end={self.span_end}, padding_value={self.padding_value})"
+
     @property
     def span_start(self) -> int:
         return self._span_start

--- a/collatable/fields/span_field.py
+++ b/collatable/fields/span_field.py
@@ -6,7 +6,7 @@ from collatable.typing import Tensor
 
 
 class SpanField(Field[Tensor]):
-    __slots__ = ["span_start", "span_end", "sequence_field", "padding_value"]
+    __slots__ = ["_span_start", "_span_end", "_padding_value"]
 
     def __init__(
         self,
@@ -26,9 +26,16 @@ class SpanField(Field[Tensor]):
 
         super().__init__(padding_value=padding_value)
 
-        self.span_start = span_start
-        self.span_end = span_end
-        self.sequence_field = sequence_field
+        self._span_start = span_start
+        self._span_end = span_end
+
+    @property
+    def span_start(self) -> int:
+        return self._span_start
+
+    @property
+    def span_end(self) -> int:
+        return self._span_end
 
     def as_array(self) -> Tensor:
         return numpy.array([self.span_start, self.span_end])

--- a/collatable/fields/tensor_field.py
+++ b/collatable/fields/tensor_field.py
@@ -7,7 +7,7 @@ from collatable.typing import ArrayLike, Tensor
 
 
 class TensorField(Field[Tensor]):
-    __slots__ = ["tensor", "padding_value"]
+    __slots__ = ["_tensor", "_padding_value"]
 
     def __init__(
         self,
@@ -15,7 +15,11 @@ class TensorField(Field[Tensor]):
         padding_value: ArrayLike = 0,
     ) -> None:
         super().__init__(padding_value=padding_value)
-        self.tensor = tensor
+        self._tensor = tensor
+
+    @property
+    def tensor(self) -> Tensor:
+        return self._tensor
 
     def __eq__(self, other: object) -> bool:
         if isinstance(self, other.__class__):
@@ -24,4 +28,4 @@ class TensorField(Field[Tensor]):
         return NotImplemented
 
     def as_array(self) -> Tensor:
-        return self.tensor
+        return self._tensor

--- a/collatable/fields/tensor_field.py
+++ b/collatable/fields/tensor_field.py
@@ -27,5 +27,11 @@ class TensorField(Field[Tensor]):
             return numpy.array_equal(self.tensor, other.tensor) and self.padding_value == other.padding_value
         return NotImplemented
 
+    def __str__(self) -> str:
+        return str(self._tensor)
+
+    def __repr__(self) -> str:
+        return f"TensorField(tensor={self._tensor}, padding_value={self._padding_value})"
+
     def as_array(self) -> Tensor:
         return self._tensor

--- a/collatable/fields/text_field.py
+++ b/collatable/fields/text_field.py
@@ -42,6 +42,12 @@ class TextField(Generic[Token, T_DataArray], SequenceField[T_DataArray]):
     def __getitem__(self, index: int) -> Token:
         return self.tokens[index]
 
+    def __str__(self) -> str:
+        return f"[{', '.join(str(token) for token in self.tokens)}]"
+
+    def __repr__(self) -> str:
+        return f"TextField(tokens={self.tokens}, padding_value={self._padding_value})"
+
     @property
     def tokens(self) -> Sequence[Token]:
         return self._tokens


### PR DESCRIPTION
- Drop references of indexer/sequence from field object to pickle field objects with minimal attributes 
- Remove `lazy` option from TextField/LabelFIeld and support only immediately indexing